### PR TITLE
CKEditor support

### DIFF
--- a/_admin.php
+++ b/_admin.php
@@ -11,8 +11,8 @@
  */
 if (!defined('DC_CONTEXT_ADMIN')) { return; }
 
-dcCore::app()->addBehavior('adminPostHeaders',array('multiTocBehaviors','postHeaders'));
-dcCore::app()->addBehavior('adminPageHeaders',array('multiTocBehaviors','postHeaders'));
+dcCore::app()->addBehavior('adminPostEditor', array('multiTocBehaviors', 'adminPostEditor'));
+dcCore::app()->addBehavior('ckeditorExtraPlugins', array('multiTocBehaviors', 'ckeditorExtraPlugins'));
 
 // Admin sidebar menu
 dcCore::app()->menu[dcAdmin::MENU_BLOG]->addItem(

--- a/_prepend.php
+++ b/_prepend.php
@@ -57,6 +57,15 @@ class multiTocBehaviors
     }
     return $res;
 	}
+
+  public static function ckeditorExtraPlugins(ArrayObject $extraPlugins)
+  {
+    $extraPlugins[] = [
+      'name'   => 'multitoc',
+      'button' => 'multiToc',
+      'url'    => DC_ADMIN_URL . 'index.php?pf=multiToc/js/ckeditor-multitoc-plugin.js',
+    ];
+  }
 	
 	public static function initStacker()
 	{

--- a/_prepend.php
+++ b/_prepend.php
@@ -41,18 +41,21 @@ class multiTocBehaviors
 		$rs->extend('rsMultiTocPost');
 	}
 	
-	public static function postHeaders()
+  public static function adminPostEditor($editor = '')
 	{
+    $res = '';
 		$s = unserialize(dcCore::app()->blog->settings->multiToc->multitoc_settings);
-		
-		return
-			(isset($s['post']['enable']) && $s['post']['enable']) ?
-			'<script src="index.php?pf=multiToc/js/post.js"></script>'.
-			'<script>'."\n".
-			"//<![CDATA[\n".
-			dcPage::jsVar('jsToolBar.prototype.elements.multiToc.title',__('Table of content')).
-			"\n//]]>\n".
-			"</script>\n" : '';
+    if (isset($s['post']['enable']) && $s['post']['enable']) {
+      if ($editor == 'dcLegacyEditor') {
+        $res = dcPage::jsJson('dc_editor_multitoc', ['title' => __('Table of content')]) .
+          dcPage::jsModuleLoad('multiToc/js/post.js', dcCore::app()->getVersion('multiToc'));
+      } elseif ($editor == 'dcCKEditor') {
+        $res = dcPage::jsJson('ck_editor_multitoc', [
+          'title'        => __('Table of content'),
+        ]);
+      }
+    }
+    return $res;
 	}
 	
 	public static function initStacker()

--- a/js/ckeditor-multitoc-plugin.js
+++ b/js/ckeditor-multitoc-plugin.js
@@ -1,0 +1,26 @@
+/*global CKEDITOR, dotclear */
+'use strict';
+
+dotclear.ck_multitoc = dotclear.getData('ck_editor_multitoc');
+
+{
+  CKEDITOR.plugins.add('multitoc', {
+    init(editor) {
+      editor.addCommand('multiTocCommand', {
+        exec: function(editor) {
+          const s = '<p>::TOC::</p>';
+          const element=CKEDITOR.dom.element.createFromHtml(s);
+          editor.insertElement(element);
+        },
+      });
+
+      var icon_path = this.path.replace('js','img');
+      editor.ui.addButton('multiToc', {
+        label: dotclear.ck_multitoc.title,
+        command: 'multiTocCommand',
+        icon: icon_path + 'bt_multitoc.png',
+        toolbar: 'insert',
+      });
+    },
+  });
+}


### PR DESCRIPTION
multiToc adds already a button in dcLegacyEditor. But when the editor is dcCKEditor, the button is missing. Moreover some javascript exceptions are raised:

> Uncaught ReferenceError: jsToolBar is not defined
>     <anonymous> http://dotclear.local/admin/index.php?pf=multiToc/js/post.js:11
> index.php:11:1
> 
> Uncaught ReferenceError: jsToolBar is not defined
>     <anonymous> http://dotclear.local/admin/post.php?id=10:55
> post.php:55:1

This pull request restricts current code (with `jsToolBar`) to dcLegacyEditor only, which fix the javascript exceptions, and add support for dcCKEditor.